### PR TITLE
[FIX] Add camelizeKeys namedExport option

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,11 @@ export default [
         exclude: 'node_modules/**',
       }),
       resolve(),
-      commonjs(),
+      commonjs({
+        namedExports: {
+          'node_modules/humps/humps.js': ['camelizeKeys'],
+        },
+      }),
       uglify(),
     ],
   },


### PR DESCRIPTION
### Fix

- add option to commonjs plugin in Rollup to handle the named export of humps.