### PR TITLE
[ENHANCEMENT] Object normalize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/src/plugins/normalize.js
+++ b/src/plugins/normalize.js
@@ -1,1 +1,4 @@
-export default ({ data }) => data.reduce((o, d) => ({ ...o, byId: { ...o.byId, [d.id]: d } }), {});
+export default ({ data }) => {
+  const dataArray = Array.isArray(data) ? data : [data];
+  return dataArray.reduce((o, d) => ({ ...o, byId: { ...o.byId, [d.id]: d } }), {});
+};

--- a/test/plugins/normalize.test.js
+++ b/test/plugins/normalize.test.js
@@ -38,4 +38,25 @@ describe(`normalize data`, () => {
       },
     });
   });
+  it(`should return the data normalized by Id`, () => {
+    const data = {
+      id: '8799873',
+      user_id: '6979873',
+      user_info: {
+        first_name: 'Geoffrey',
+      },
+    };
+
+    expect(normalize({ data })).toEqual({
+      byId: {
+        '8799873': {
+          id: '8799873',
+          user_id: '6979873',
+          user_info: {
+            first_name: 'Geoffrey',
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
### Added

- when you receive a single object as result (not an array of objects), the data should also be normalized with the plugin now

API result:

```js

{
  data: {
    id: '8799873',
    user_id: '6979873',
    user_info: {
      first_name: 'Geoffrey',
    },
  }
}
```

normalize result:

```js

byId: {
  '8799873': {
    id: '8799873',
    user_id: '6979873',
    user_info: {
      first_name: 'Geoffrey',
    }
  }
}

```