### PR TITLE
[FEATURE] customActions option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ You should provide `getAccessToken` **or** `accessToken`.
 
 You can optionally pass in a `baseUrl` for the API calls (default is set to `https://api.teamleader.eu`)
 
+## Custom actions
+
+* `customActions`: (Object) domain as property -> array of actions as value
+
+In the example below we are adding `api.contacts.deleted` and `api.tags.deleted` and `api.tags.linkToInvoice`
+
+```js
+import API from '@teamleader/api';
+
+const api = API({
+  getAccessToken: () => 'thisisatoken', // async or sync function
+  customActions: {
+    contacts: ['deleted'],
+    tags: ['deleted', 'linkToInvoice'],
+  },
+});
+```
+
 ## Plugins
 
 You can provide an extra array of plugins to manipulate your data.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can optionally pass in a `baseUrl` for the API calls (default is set to `htt
 
 * `customActions`: (Object) domain as property -> array of actions as value
 
-In the example below we are adding `api.contacts.deleted` and `api.tags.deleted` and `api.tags.linkToInvoice`
+In the example below we are adding `api.contacts.deleted`, `api.tags.deleted` and `api.tags.linkToInvoice`
 
 ```js
 import API from '@teamleader/api';

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ You can optionally pass in a `baseUrl` for the API calls (default is set to `htt
 
 ## Custom actions
 
+You can also add extra custom actions to the domains (which will be handled the same way as the available actions).
+
 * `customActions`: (Object) domain as property -> array of actions as value
 
-In the example below we are adding `api.contacts.deleted`, `api.tags.deleted` and `api.tags.linkToInvoice`
+In the example below we are extending `api.contacts` with `deleted` and `api.tags` with `deleted` and `linkToInvoice`
 
 ```js
 import API from '@teamleader/api';

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint --config ./.eslintrc --ignore-path ./.eslintignore src",
     "lint:fix": "npm run lint -- --fix",
+    "prepublishOnly": "npm run build",
     "precommit": "pretty-quick --staged"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "rollup -c",
     "start": "rollup -c -w",
     "test": "jest",
+    "test:watch": "jest --watch",
     "lint": "eslint --config ./.eslintrc --ignore-path ./.eslintignore src",
     "lint:fix": "npm run lint -- --fix",
     "precommit": "pretty-quick --staged"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/src/domains/activityTypes.js
+++ b/src/domains/activityTypes.js
@@ -4,7 +4,7 @@ const activityTypes = config =>
   createDomain({
     config,
     domain: 'activityTypes',
-    actions: ['list'],
+    actions: ['list', ...(config.customActions || [])],
   });
 
 export default activityTypes;

--- a/src/domains/businessTypes.js
+++ b/src/domains/businessTypes.js
@@ -4,7 +4,7 @@ const businessTypes = config =>
   createDomain({
     config,
     domain: 'businessTypes',
-    actions: ['list'],
+    actions: ['list', ...(config.customActions || [])],
   });
 
 export default businessTypes;

--- a/src/domains/companies.js
+++ b/src/domains/companies.js
@@ -4,7 +4,7 @@ const companies = config =>
   createDomain({
     config,
     domain: 'companies',
-    actions: ['list', 'info', 'add', 'update', 'delete', 'tag'],
+    actions: ['list', 'info', 'add', 'update', 'delete', 'tag', ...(config.customActions || [])],
   });
 
 export default companies;

--- a/src/domains/contacts.js
+++ b/src/domains/contacts.js
@@ -4,7 +4,16 @@ const contacts = config =>
   createDomain({
     config,
     domain: 'contacts',
-    actions: ['list', 'info', 'add', 'update', 'delete', 'linkToCompany', 'unlinkFromCompany'],
+    actions: [
+      'list',
+      'info',
+      'add',
+      'update',
+      'delete',
+      'linkToCompany',
+      'unlinkFromCompany',
+      ...(config.customActions || []),
+    ],
   });
 
 export default contacts;

--- a/src/domains/creditNotes.js
+++ b/src/domains/creditNotes.js
@@ -4,7 +4,7 @@ const creditNotes = config =>
   createDomain({
     config,
     domain: 'creditNotes',
-    actions: ['list', 'info'],
+    actions: ['list', 'info', ...(config.customActions || [])],
   });
 
 export default creditNotes;

--- a/src/domains/dealPhases.js
+++ b/src/domains/dealPhases.js
@@ -4,7 +4,7 @@ const dealPhases = config =>
   createDomain({
     config,
     domain: 'dealPhases',
-    actions: ['list'],
+    actions: ['list', ...(config.customActions || [])],
   });
 
 export default dealPhases;

--- a/src/domains/departments.js
+++ b/src/domains/departments.js
@@ -4,7 +4,7 @@ const departments = config =>
   createDomain({
     config,
     domain: 'departments',
-    actions: ['list', 'info'],
+    actions: ['list', 'info', ...(config.customActions || [])],
   });
 
 export default departments;

--- a/src/domains/events.js
+++ b/src/domains/events.js
@@ -4,7 +4,7 @@ const events = config =>
   createDomain({
     config,
     domain: 'events',
-    actions: ['list', 'info', 'create'],
+    actions: ['list', 'info', 'create', ...(config.customActions || [])],
   });
 
 export default events;

--- a/src/domains/invoices.js
+++ b/src/domains/invoices.js
@@ -4,7 +4,17 @@ const invoices = config =>
   createDomain({
     config,
     domain: 'invoices',
-    actions: ['list', 'info', 'draft', 'update', 'copy', 'book', 'delete', 'registerPayment'],
+    actions: [
+      'list',
+      'info',
+      'draft',
+      'update',
+      'copy',
+      'book',
+      'delete',
+      'registerPayment',
+      ...(config.customActions || []),
+    ],
   });
 
 export default invoices;

--- a/src/domains/milestones.js
+++ b/src/domains/milestones.js
@@ -4,7 +4,7 @@ const milestones = config =>
   createDomain({
     config,
     domain: 'milestones',
-    actions: ['list', 'info', 'create', 'update'],
+    actions: ['list', 'info', 'create', 'update', ...(config.customActions || [])],
   });
 
 export default milestones;

--- a/src/domains/projects.js
+++ b/src/domains/projects.js
@@ -4,7 +4,16 @@ const projects = config =>
   createDomain({
     config,
     domain: 'projects',
-    actions: ['list', 'info', 'create', 'update', 'delete', 'addParticipant', 'updateParticipant'],
+    actions: [
+      'list',
+      'info',
+      'create',
+      'update',
+      'delete',
+      'addParticipant',
+      'updateParticipant',
+      ...(config.customActions || []),
+    ],
   });
 
 export default projects;

--- a/src/domains/quotations.js
+++ b/src/domains/quotations.js
@@ -4,7 +4,7 @@ const quotations = config =>
   createDomain({
     config,
     domain: 'quotations',
-    actions: ['info'],
+    actions: ['info', ...(config.customActions || [])],
   });
 
 export default quotations;

--- a/src/domains/tags.js
+++ b/src/domains/tags.js
@@ -4,7 +4,7 @@ const tags = config =>
   createDomain({
     config,
     domain: 'tags',
-    actions: ['list'],
+    actions: ['list', ...(config.customActions || [])],
   });
 
 export default tags;

--- a/src/domains/taxRates.js
+++ b/src/domains/taxRates.js
@@ -4,7 +4,7 @@ const taxRates = config =>
   createDomain({
     config,
     domain: 'taxRates',
-    actions: ['list'],
+    actions: ['list', ...(config.customActions || [])],
   });
 
 export default taxRates;

--- a/src/domains/users.js
+++ b/src/domains/users.js
@@ -4,7 +4,7 @@ const users = config =>
   createDomain({
     config,
     domain: 'users',
-    actions: ['me', 'list', 'info'],
+    actions: ['me', 'list', 'info', ...(config.customActions || [])],
   });
 
 export default users;

--- a/src/main.js
+++ b/src/main.js
@@ -31,31 +31,31 @@ const createGetAccessToken = config => {
 
 const API = config => {
   const getAccessToken = createGetAccessToken(config);
-  const { baseUrl = 'https://api.teamleader.eu', plugins } = config;
+  const { baseUrl = 'https://api.teamleader.eu', plugins, customMethods = {} } = config;
 
   const domainConfig = { getAccessToken, baseUrl, plugins };
 
   return {
-    contacts: contacts(domainConfig),
+    contacts: contacts({ ...domainConfig, customMethods: customMethods.contacts }),
 
-    events: events(domainConfig),
-    activityTypes: activityTypes(domainConfig),
+    events: events({ ...domainConfig, customMethods: customMethods.events }),
+    activityTypes: activityTypes({ ...domainConfig, customMethods: customMethods.activityTypes }),
 
-    invoices: invoices(domainConfig),
-    creditNotes: creditNotes(domainConfig),
-    taxRates: taxRates(domainConfig),
+    invoices: invoices({ ...domainConfig, customMethods: customMethods.invoices }),
+    creditNotes: creditNotes({ ...domainConfig, customMethods: customMethods.creditNotes }),
+    taxRates: taxRates({ ...domainConfig, customMethods: customMethods.taxRates }),
 
-    companies: companies(domainConfig),
-    businessTypes: businessTypes(domainConfig),
-    quotations: quotations(domainConfig),
-    tags: tags(domainConfig),
-    dealPhases: dealPhases(domainConfig),
+    companies: companies({ ...domainConfig, customMethods: customMethods.companies }),
+    businessTypes: businessTypes({ ...domainConfig, customMethods: customMethods.businessTypes }),
+    quotations: quotations({ ...domainConfig, customMethods: customMethods.quotations }),
+    tags: tags({ ...domainConfig, customMethods: customMethods.tags }),
+    dealPhases: dealPhases({ ...domainConfig, customMethods: customMethods.dealPhases }),
 
-    projects: projects(domainConfig),
-    milestones: milestones(domainConfig),
+    projects: projects({ ...domainConfig, customMethods: customMethods.projects }),
+    milestones: milestones({ ...domainConfig, customMethods: customMethods.milestones }),
 
-    departments: departments(domainConfig),
-    users: users(domainConfig),
+    departments: departments({ ...domainConfig, customMethods: customMethods.departments }),
+    users: users({ ...domainConfig, customMethods: customMethods.users }),
   };
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -31,31 +31,31 @@ const createGetAccessToken = config => {
 
 const API = config => {
   const getAccessToken = createGetAccessToken(config);
-  const { baseUrl = 'https://api.teamleader.eu', plugins, customMethods = {} } = config;
+  const { baseUrl = 'https://api.teamleader.eu', plugins, customActions = {} } = config;
 
   const domainConfig = { getAccessToken, baseUrl, plugins };
 
   return {
-    contacts: contacts({ ...domainConfig, customMethods: customMethods.contacts }),
+    contacts: contacts({ ...domainConfig, customActions: customActions.contacts }),
 
-    events: events({ ...domainConfig, customMethods: customMethods.events }),
-    activityTypes: activityTypes({ ...domainConfig, customMethods: customMethods.activityTypes }),
+    events: events({ ...domainConfig, customActions: customActions.events }),
+    activityTypes: activityTypes({ ...domainConfig, customActions: customActions.activityTypes }),
 
-    invoices: invoices({ ...domainConfig, customMethods: customMethods.invoices }),
-    creditNotes: creditNotes({ ...domainConfig, customMethods: customMethods.creditNotes }),
-    taxRates: taxRates({ ...domainConfig, customMethods: customMethods.taxRates }),
+    invoices: invoices({ ...domainConfig, customActions: customActions.invoices }),
+    creditNotes: creditNotes({ ...domainConfig, customActions: customActions.creditNotes }),
+    taxRates: taxRates({ ...domainConfig, customActions: customActions.taxRates }),
 
-    companies: companies({ ...domainConfig, customMethods: customMethods.companies }),
-    businessTypes: businessTypes({ ...domainConfig, customMethods: customMethods.businessTypes }),
-    quotations: quotations({ ...domainConfig, customMethods: customMethods.quotations }),
-    tags: tags({ ...domainConfig, customMethods: customMethods.tags }),
-    dealPhases: dealPhases({ ...domainConfig, customMethods: customMethods.dealPhases }),
+    companies: companies({ ...domainConfig, customActions: customActions.companies }),
+    businessTypes: businessTypes({ ...domainConfig, customActions: customActions.businessTypes }),
+    quotations: quotations({ ...domainConfig, customActions: customActions.quotations }),
+    tags: tags({ ...domainConfig, customActions: customActions.tags }),
+    dealPhases: dealPhases({ ...domainConfig, customActions: customActions.dealPhases }),
 
-    projects: projects({ ...domainConfig, customMethods: customMethods.projects }),
-    milestones: milestones({ ...domainConfig, customMethods: customMethods.milestones }),
+    projects: projects({ ...domainConfig, customActions: customActions.projects }),
+    milestones: milestones({ ...domainConfig, customActions: customActions.milestones }),
 
-    departments: departments({ ...domainConfig, customMethods: customMethods.departments }),
-    users: users({ ...domainConfig, customMethods: customMethods.users }),
+    departments: departments({ ...domainConfig, customActions: customActions.departments }),
+    users: users({ ...domainConfig, customActions: customActions.users }),
   };
 };
 

--- a/test/domains/activityTypes.test.js
+++ b/test/domains/activityTypes.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'deleted'];

--- a/test/domains/activityTypes.test.js
+++ b/test/domains/activityTypes.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'deleted'];
+
+    const obj = await activityTypes(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/businessTypes.test.js
+++ b/test/domains/businessTypes.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'deleted'];
+
+    const obj = await businessTypes(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/businessTypes.test.js
+++ b/test/domains/businessTypes.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'deleted'];

--- a/test/domains/companies.test.js
+++ b/test/domains/companies.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'add', 'update', 'delete', 'tag', 'deleted'];
+
+    const obj = await companies(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/companies.test.js
+++ b/test/domains/companies.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'add', 'update', 'delete', 'tag', 'deleted'];

--- a/test/domains/contacts.test.js
+++ b/test/domains/contacts.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'add', 'update', 'delete', 'linkToCompany', 'unlinkFromCompany', 'deleted'];
+
+    const obj = await contacts(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/contacts.test.js
+++ b/test/domains/contacts.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'add', 'update', 'delete', 'linkToCompany', 'unlinkFromCompany', 'deleted'];

--- a/test/domains/creditNotes.test.js
+++ b/test/domains/creditNotes.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'deleted'];
+
+    const obj = await creditNotes(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/creditNotes.test.js
+++ b/test/domains/creditNotes.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'deleted'];

--- a/test/domains/dealPhases.test.js
+++ b/test/domains/dealPhases.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'deleted'];
+
+    const obj = await dealPhases(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/dealPhases.test.js
+++ b/test/domains/dealPhases.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'deleted'];

--- a/test/domains/departments.test.js
+++ b/test/domains/departments.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'deleted'];

--- a/test/domains/departments.test.js
+++ b/test/domains/departments.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'deleted'];
+
+    const obj = await departments(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/events.test.js
+++ b/test/domains/events.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'create', 'deleted'];

--- a/test/domains/events.test.js
+++ b/test/domains/events.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'create', 'deleted'];
+
+    const obj = await events(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/invoices.test.js
+++ b/test/domains/invoices.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'draft', 'update', 'copy', 'book', 'delete', 'registerPayment', 'deleted'];
+
+    const obj = await invoices(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/invoices.test.js
+++ b/test/domains/invoices.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'draft', 'update', 'copy', 'book', 'delete', 'registerPayment', 'deleted'];

--- a/test/domains/milestones.test.js
+++ b/test/domains/milestones.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'create', 'update', 'deleted'];
+
+    const obj = await milestones(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/milestones.test.js
+++ b/test/domains/milestones.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'create', 'update', 'deleted'];

--- a/test/domains/projects.test.js
+++ b/test/domains/projects.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'info', 'create', 'update', 'delete', 'addParticipant', 'updateParticipant', 'deleted'];
+
+    const obj = await projects(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/projects.test.js
+++ b/test/domains/projects.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'info', 'create', 'update', 'delete', 'addParticipant', 'updateParticipant', 'deleted'];

--- a/test/domains/quotations.test.js
+++ b/test/domains/quotations.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['info', 'deleted'];
+
+    const obj = await quotations(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/quotations.test.js
+++ b/test/domains/quotations.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['info', 'deleted'];

--- a/test/domains/tags.test.js
+++ b/test/domains/tags.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'deleted'];

--- a/test/domains/tags.test.js
+++ b/test/domains/tags.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'deleted'];
+
+    const obj = await tags(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/taxRates.test.js
+++ b/test/domains/taxRates.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['list', 'deleted'];

--- a/test/domains/taxRates.test.js
+++ b/test/domains/taxRates.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['list', 'deleted'];
+
+    const obj = await taxRates(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/users.test.js
+++ b/test/domains/users.test.js
@@ -13,4 +13,18 @@ describe(`check if domain contains correct methods`, () => {
 
     expect(Object.keys(obj).sort()).toEqual(methods.sort());
   });
+
+  it(`should contain add the extra custom method`, async () => {
+    const config = {
+      getAccessToken: () => 'token',
+      baseUrl: 'https://api.teamleader.eu',
+      customMethods: ['deleted'],
+    };
+
+    const methods = ['me', 'list', 'info', 'deleted'];
+
+    const obj = await users(config);
+
+    expect(Object.keys(obj).sort()).toEqual(methods.sort());
+  });
 });

--- a/test/domains/users.test.js
+++ b/test/domains/users.test.js
@@ -18,7 +18,7 @@ describe(`check if domain contains correct methods`, () => {
     const config = {
       getAccessToken: () => 'token',
       baseUrl: 'https://api.teamleader.eu',
-      customMethods: ['deleted'],
+      customActions: ['deleted'],
     };
 
     const methods = ['me', 'list', 'info', 'deleted'];

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,10 +1,10 @@
 import API from '../src/main';
 
 describe('fetch response handling', () => {
-  it('shoud add the customMethods to the correct domains', () => {
+  it('shoud add the customActions to the correct domains', () => {
     const api = API({
       getAccessToken: () => 'thisisatoken', // async or sync function
-      customMethods: {
+      customActions: {
         contacts: ['deleted'],
         activityTypes: ['deleted'],
       },

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,31 @@
+import API from '../src/main';
+
+describe('fetch response handling', () => {
+  it('shoud add the customMethods to the correct domains', () => {
+    const api = API({
+      getAccessToken: () => 'thisisatoken', // async or sync function
+      customMethods: {
+        contacts: ['deleted'],
+        activityTypes: ['deleted'],
+      },
+    });
+
+    const activityTypesMethods = ['list', 'deleted'];
+    expect(Object.keys(api.activityTypes).sort()).toEqual(activityTypesMethods.sort());
+
+    const contactsMethods = [
+      'list',
+      'info',
+      'add',
+      'update',
+      'delete',
+      'linkToCompany',
+      'unlinkFromCompany',
+      'deleted',
+    ];
+    expect(Object.keys(api.contacts).sort()).toEqual(contactsMethods.sort());
+
+    const dealPhasesMethods = ['list'];
+    expect(Object.keys(api.dealPhases).sort()).toEqual(dealPhasesMethods.sort());
+  });
+});


### PR DESCRIPTION
### Added

You can now add extra custom actions to the domains (which will be handled the same way as the available actions).

* `customActions`: (Object) domain as property -> array of actions as value

In the example below we are extending `api.contacts` with `deleted` and `api.tags` with `deleted` and `linkToInvoice`

```js
import API from '@teamleader/api';

const api = API({
  getAccessToken: () => 'thisisatoken', // async or sync function
  customActions: {
    contacts: ['deleted'],
    tags: ['deleted', 'linkToInvoice'],
  },
});
```

- extra tests
- `prePublishOnly` script to build before `npm publish`
- `test:watch` script