### PR TITLE
[FEATURE] request plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ const api = API({
 
 You can provide an extra array of plugins to manipulate your data.
 
-* `plugins`: (Array) Array of functions that receive data and return (manipulated) data.
+* `plugins`: (Object) has 2 keys `request` / `response`, each key should be an Array with plugins.
 
-A plugin function has the signature `data => data`
+A plugin is a function that receives data (request params or response data) & returns manipulated data, it has the signature `data => data`.
 
 You can provide them in 2 ways.
 
@@ -85,11 +85,11 @@ If you provide plugins at `root level` and at `action level` they are merged int
 
 ```js
 import API from '@teamleader/api';
-import { camelCase, normalize } from '@teamleader/api'; // exported as named exports
+import { camelCase, normalize, snakeCase } from '@teamleader/api'; // exported as named exports
 
 const { users } = API({
   getAccessToken: () => 'thisisatoken', // async or sync function
-  plugins: [camelCase], // at root level
+  plugins: { response: [camelCase], request: [snakeCase] }, // at root level
 });
 
 // own plugin
@@ -97,18 +97,18 @@ const addMeta = data => ({ ...data, meta: { size: data.length } });
 
 const init = async () => {
   // (options, plugins)
-  const me = await users.me(undefined, [normalize, addMeta]); // at action level
+  const me = await users.me(undefined, { response: [normalize, addMeta] }); // at action level
   console.log(me);
 };
 ```
 
-Both camelCase and normalize are exported as named exports for convenience.
+`camelCase`, `snakeCase` & `normalize` are exported as named exports for convenience.
 
 Following the example above:
 
 ### camelCase
 
-Recursively convert object keys to camelCase.
+Recursively convert object keys to camelCase (can be used for response).
 
 data in:
 
@@ -150,6 +150,56 @@ data out:
       userId: '298034',
       userInfo: {
         firstName: 'John',
+      },
+    },
+  ];
+}
+```
+
+### snakeCase
+
+Recursively convert object keys to snakeCase (can be used for request).
+
+data in:
+
+```js
+{
+  data: [
+    {
+      id: '8799873',
+      userId: '6979873',
+      userInfo: {
+        firstName: 'Geoffrey',
+      },
+    },
+    {
+      id: '3287687',
+      userId: '298034',
+      userInfo: {
+        firstName: 'John',
+      },
+    },
+  ];
+}
+```
+
+data out:
+
+```js
+{
+  data: [
+    {
+      id: '8799873',
+      user_id: '6979873',
+      user_info: {
+        first_name: 'Geoffrey',
+      },
+    },
+    {
+      id: '3287687',
+      user_id: '298034',
+      user_info: {
+        first_name: 'John',
       },
     },
   ];

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const api = API({
 
 You can provide an extra array of plugins to manipulate your data.
 
-* `plugins`: (Object) has 2 keys `request` / `response`, each key should be an Array with plugins.
+* `plugins`: (Object) has 2 keys `request` / `response`, each property can contain an Array with plugins.
 
 A plugin is a function that receives data (request params or response data) & returns manipulated data, it has the signature `data => data`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "homepage": "https://github.com/teamleadercrm/sdk-js#readme",
   "dependencies": {
-    "humps": "^2.0.1"
+    "humps": "^2.0.1",
+    "snakecase-keys": "^1.2.0"
   }
 }

--- a/src/plugins/snakeCase.js
+++ b/src/plugins/snakeCase.js
@@ -1,0 +1,2 @@
+import snakeCaseKeys from 'snakecase-keys';
+export default snakeCaseKeys;

--- a/src/utils/call.js
+++ b/src/utils/call.js
@@ -33,9 +33,12 @@ const checkStatus = response => {
   });
 };
 
-const call = (url, options, plugins = []) =>
-  fetch(url, options)
+const call = (url, options, plugins = {}) => {
+  const { response: responsePlugins = [] } = plugins;
+
+  return fetch(url, options)
     .then(checkStatus)
-    .then(data => flow(data, plugins));
+    .then(data => flow(data, responsePlugins));
+};
 
 export default call;

--- a/src/utils/createDomain.js
+++ b/src/utils/createDomain.js
@@ -2,15 +2,30 @@ import createFetchParameters from './createFetchParameters';
 import call from './call';
 
 const createDomain = ({ config, domain, actions = [], custom = {} } = {}) => {
-  const handler = (action, params) => createFetchParameters(config, domain, action, params);
-  const { plugins: globalPlugins = [] } = config;
+  const handler = (action, params, localPlugins) => {
+    const { request: localRequestPlugins = [], response: localResponsePlugins = [] } = localPlugins;
+    const { request: globalRequestPlugins = [], response: globalResponsePlugins = [] } = config.plugins || {};
+
+    return createFetchParameters(
+      {
+        ...config,
+        plugins: {
+          request: [...globalRequestPlugins, ...localRequestPlugins],
+          response: [...globalResponsePlugins, ...localResponsePlugins],
+        },
+      },
+      domain,
+      action,
+      params,
+    );
+  };
 
   const methods = actions.reduce(
     (obj, action) => ({
       ...obj,
-      [action]: async (params, plugins = []) => {
-        const { url, options } = await handler(action, params);
-        return call(url, options, [...globalPlugins, ...plugins]);
+      [action]: async (params, plugins = {}) => {
+        const { url, options, plugins: { response: responsePlugins = [] } } = await handler(action, params, plugins);
+        return call(url, options, responsePlugins);
       },
     }),
     {},

--- a/src/utils/createFetchParameters.js
+++ b/src/utils/createFetchParameters.js
@@ -1,20 +1,23 @@
 import createHeaders from '../utils/createHeaders';
+import flow from './flow';
 
-const createFetchParameters = async (config, domainName, action, attributes = {}) => {
-  const { getAccessToken, baseUrl, plugins = [] } = config;
+const createFetchParameters = async (config, domainName, action, params = {}) => {
+  const { getAccessToken, baseUrl } = config;
+  const { request: requestPlugins = [] } = config.plugins || {};
+
   const headers = await createHeaders({ getAccessToken });
   const url = `${baseUrl}/${domainName}.${action}`;
 
   const options = {
     headers,
-    body: JSON.stringify(attributes),
+    body: JSON.stringify(flow(params, requestPlugins)),
     method: 'POST',
   };
 
   return {
     url,
     options,
-    plugins,
+    plugins: config.plugins || {},
   };
 };
 

--- a/test/plugins/snakeCase.test.js
+++ b/test/plugins/snakeCase.test.js
@@ -1,0 +1,23 @@
+import snakeCase from '../../src/plugins/snakeCase';
+
+describe(`snakeCase data`, () => {
+  it(`should return the data snakeCased`, () => {
+    const data = {
+      id: '8799873',
+      userId: '6979873',
+      userInfo: {
+        firstName: 'Geoffrey',
+      },
+    };
+
+    expect(snakeCase({ data })).toEqual({
+      data: {
+        id: '8799873',
+        user_id: '6979873',
+        user_info: {
+          first_name: 'Geoffrey',
+        },
+      },
+    });
+  });
+});

--- a/test/utils/call.test.js
+++ b/test/utils/call.test.js
@@ -56,7 +56,7 @@ describe('fetch response handling', () => {
       }),
     );
 
-    call(undefined, undefined, [camelCase]).then(jsonResponse => {
+    call(undefined, undefined, { response: [camelCase] }).then(jsonResponse => {
       expect(jsonResponse).toEqual({ data: { userId: 'bar' } });
     });
   });

--- a/test/utils/createFetchParameters.test.js
+++ b/test/utils/createFetchParameters.test.js
@@ -1,4 +1,5 @@
 import createFetchParameters from '../../src/utils/createFetchParameters';
+import snakeCaseKeys from '../../src/plugins/snakeCase';
 
 describe(`create fetch parameters`, () => {
   const getAccessToken = () => 'token';
@@ -7,7 +8,7 @@ describe(`create fetch parameters`, () => {
   const config = {
     getAccessToken,
     baseUrl: 'https://api.teamleader.eu',
-    plugins: [plugin],
+    plugins: { request: [plugin] },
   };
 
   const domain = 'contacts';
@@ -15,6 +16,8 @@ describe(`create fetch parameters`, () => {
 
   const params = {
     id: '48684984984',
+    user_id: '848494985',
+    firstName: 'john',
   };
 
   it(`should return the correct url`, async () => {
@@ -24,12 +27,34 @@ describe(`create fetch parameters`, () => {
 
   it(`should return the provided plugins`, async () => {
     const obj = await createFetchParameters(config, domain, action);
-    expect(obj.plugins).toEqual([plugin]);
+    expect(obj.plugins).toEqual({ request: [plugin] });
   });
 
   it(`should return the correct Authorization header`, async () => {
     const obj = await createFetchParameters(config, domain, action);
     expect(obj.options.headers.Authorization).toEqual(`Bearer ${getAccessToken()}`);
+  });
+
+  it(`should return the correct body data`, async () => {
+    const obj = await createFetchParameters(config, domain, action, params);
+    expect(obj.options.body).toEqual(JSON.stringify(params));
+  });
+
+  it(`should return the correct body data after running the plugin`, async () => {
+    const obj = await createFetchParameters(
+      { ...config, plugins: { request: [snakeCaseKeys] } },
+      domain,
+      action,
+      params,
+    );
+
+    const snakeCasedParams = {
+      id: '48684984984',
+      user_id: '848494985',
+      first_name: 'john',
+    };
+
+    expect(obj.options.body).toEqual(JSON.stringify(snakeCasedParams));
   });
 
   it(`should return the correct body data`, async () => {


### PR DESCRIPTION
### Added

- way to pass in plugins for request data

```js
import API from '@teamleader/api';
import { camelCase, normalize, snakeCase } from '@teamleader/api'; // exported as named exports

const { users } = API({
  getAccessToken: () => 'thisisatoken', // async or sync function
  plugins: { response: [camelCase], request: [snakeCase] }, // at root level
});

// own plugin
const addMeta = data => ({ ...data, meta: { size: data.length } });

const init = async () => {
  // (options, plugins)
  const me = await users.me(undefined, { response: [normalize, addMeta] }); // at action level
  console.log(me);
};
```

### Changed

- **[BREAKING CHANGE]:** changed the way plugins are passed (via plugins object with `request` and `response` key) 