### PR TITLE
[Fix] Export snakeCase function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/src/main.js
+++ b/src/main.js
@@ -143,5 +143,6 @@ export { default as createDomain } from './utils/createDomain';
 
 export { default as camelCase } from './plugins/camelCase';
 export { default as normalize } from './plugins/normalize';
+export { default as snakeCase } from './plugins/snakeCase';
 
 export default API;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,6 +1,4 @@
-import API from '../src/main';
-import camelCase from '../src/plugins/camelCase';
-import normalize from '../src/plugins/normalize';
+import API, { camelCase, normalize } from '../src/main';
 
 describe('fetch response handling', () => {
   const mockFetch = desiredResponse => (window.fetch = () => Promise.resolve(desiredResponse));

--- a/test/plugins/camelCase.test.js
+++ b/test/plugins/camelCase.test.js
@@ -1,4 +1,4 @@
-import camelCase from '../../src/plugins/camelCase';
+import { camelCase } from '../../src/main';
 
 describe(`camelCase data`, () => {
   it(`should return the data camelCased`, () => {

--- a/test/plugins/normalize.test.js
+++ b/test/plugins/normalize.test.js
@@ -1,4 +1,4 @@
-import normalize from '../../src/plugins/normalize';
+import { normalize } from '../../src/main';
 
 describe(`normalize data`, () => {
   it(`should return the data normalized by Id`, () => {

--- a/test/plugins/snakeCase.test.js
+++ b/test/plugins/snakeCase.test.js
@@ -1,4 +1,4 @@
-import snakeCase from '../../src/plugins/snakeCase';
+import { snakeCase } from '../../src/main';
 
 describe(`snakeCase data`, () => {
   it(`should return the data snakeCased`, () => {


### PR DESCRIPTION
### Changed

- export `snakeCase` from main for easy access

```js
import { snakeCase } from '@teamleader/api';
```

- imported via main in the test (to spot if the imports are wrong)
- bumped a patch version