### PR TITLE
[Fix] Dependency Uglify issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "homepage": "https://github.com/teamleadercrm/sdk-js#readme",
   "dependencies": {
-    "humps": "^2.0.1",
-    "snakecase-keys": "^1.2.0"
+    "humps": "^2.0.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default [
       resolve(),
       commonjs({
         namedExports: {
-          'node_modules/humps/humps.js': ['camelizeKeys'],
+          'node_modules/humps/humps.js': ['camelizeKeys', 'decamelizeKeys'],
         },
       }),
       uglify(),

--- a/src/plugins/snakeCase.js
+++ b/src/plugins/snakeCase.js
@@ -1,2 +1,6 @@
-import snakeCaseKeys from 'snakecase-keys';
-export default snakeCaseKeys;
+import { decamelizeKeys } from 'humps';
+
+export default object =>
+  decamelizeKeys(object, {
+    separator: '_',
+  });


### PR DESCRIPTION
### Fixed

- had a weird issue with a dependency not being bundled for ES5, fixed it by removing it and using decamelizeKeys from `humps` instead (already used for `camelCase`)