### PR TITLE
Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You should provide `getAccessToken` **or** `accessToken`.
 * `baseUrl`: (string) url the sdk should use to call the API (default is set to `https://api.teamleader.eu`)
 * `version`: (string) specific version of the API in YYYY-MM-DD format (see the [Teamleader documentation](https://developer.teamleader.eu/#/introduction/changes-&-upgrades/upgrading-your-api-version))
 
-`version` can also be provided at a call level, in that case it will override the global setting.
+`version` can also be provided at action level, in that case it will override the root setting.
 
 ```js
 import API from '@teamleader/api';

--- a/README.md
+++ b/README.md
@@ -46,7 +46,26 @@ You should provide `getAccessToken` **or** `accessToken`.
 * `getAccessToken`: (function) a (a)sync function that returns a valid access token, triggered on each API call
 * `accessToken`: (string) an access token
 
-You can optionally pass in a `baseUrl` for the API calls (default is set to `https://api.teamleader.eu`)
+### optional
+
+* `baseUrl`: (string) url the sdk should use to call the API (default is set to `https://api.teamleader.eu`)
+* `version`: (string) specific version of the API in YYYY-MM-DD format (see the [Teamleader documentation](https://developer.teamleader.eu/#/introduction/changes-&-upgrades/upgrading-your-api-version))
+
+`version` can also be provided at a call level, in that case it will override the global setting.
+
+```js
+import API from '@teamleader/api';
+
+const { users } = API({
+  getAccessToken: () => 'thisisatoken',
+  version: '2018-10-30',
+});
+
+const init = async () => {
+  // (options, plugins)
+  const me = await users.me(undefined, { version: '2018-09-12' }); // version 2018-09-12 is used
+};
+```
 
 ## Custom actions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/src/utils/createFetchOptions.js
+++ b/src/utils/createFetchOptions.js
@@ -2,10 +2,10 @@ import createRequestHeaders from './createRequestHeaders';
 import flow from './flow';
 
 export default async ({ configuration, parameters } = {}) => {
-  const { getAccessToken, plugins: { request: requestPlugins = [] } = {} } = configuration;
+  const { getAccessToken, plugins: { request: requestPlugins = [] } = {}, version } = configuration;
 
   return {
-    headers: await createRequestHeaders(getAccessToken),
+    headers: await createRequestHeaders({ getAccessToken, version }),
     body: JSON.stringify(flow(parameters, requestPlugins)),
     method: 'POST',
   };

--- a/src/utils/createRequestHeaders.js
+++ b/src/utils/createRequestHeaders.js
@@ -1,8 +1,17 @@
-export default async getAccessToken => {
+export default async ({ getAccessToken, version = undefined } = {}) => {
   const accessToken = await getAccessToken();
 
-  return {
+  const headers = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${accessToken}`,
   };
+
+  if (version !== undefined) {
+    return {
+      ...headers,
+      'X-Api-Version': version,
+    };
+  }
+
+  return headers;
 };

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -1,13 +1,30 @@
 import mergePlugins from './mergePlugins';
 
 export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
-  const { getAccessToken, baseUrl = 'https://api.teamleader.eu' } = globalConfiguration; // only destruct what we might need on request level
+  const { getAccessToken, baseUrl = 'https://api.teamleader.eu', version: globalVersion } = globalConfiguration; // only destruct what we might need on request level
+  const { version: localVersion } = localConfiguration;
 
   const plugins = mergePlugins(globalConfiguration.plugins, localConfiguration.plugins);
 
-  return {
+  const mergedConfiguration = {
     getAccessToken,
     baseUrl,
     plugins,
   };
+
+  if (localVersion !== undefined) {
+    return {
+      ...mergedConfiguration,
+      version: localVersion,
+    };
+  }
+
+  if (globalVersion !== undefined) {
+    return {
+      ...mergedConfiguration,
+      version: globalVersion,
+    };
+  }
+
+  return mergedConfiguration;
 };

--- a/test/utils/createRequestHeaders.test.js
+++ b/test/utils/createRequestHeaders.test.js
@@ -9,7 +9,19 @@ describe(`create header object`, () => {
       Authorization: `Bearer token`,
     };
 
-    await expect(createRequestHeaders(getAccessToken)).resolves.toEqual(headers);
+    await expect(createRequestHeaders({ getAccessToken })).resolves.toEqual(headers);
+  });
+
+  it(`should be able to pass in a version`, async () => {
+    const getAccessToken = () => 'token';
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer token`,
+      'X-Api-Version': '2018-09-12',
+    };
+
+    await expect(createRequestHeaders({ getAccessToken, version: '2018-09-12' })).resolves.toEqual(headers);
   });
 
   it(`should be able to pass in a async getAccessToken function`, async () => {
@@ -25,6 +37,6 @@ describe(`create header object`, () => {
       Authorization: `Bearer token`,
     };
 
-    await expect(createRequestHeaders(getAccessToken)).resolves.toEqual(headers);
+    await expect(createRequestHeaders({ getAccessToken })).resolves.toEqual(headers);
   });
 });

--- a/test/utils/mergeConfigurations.test.js
+++ b/test/utils/mergeConfigurations.test.js
@@ -12,6 +12,7 @@ describe(`merge configurations`, () => {
     plugins: {
       response: [camelCase],
     },
+    version: '2018-09-20',
   };
 
   const localConfiguration = {
@@ -30,6 +31,44 @@ describe(`merge configurations`, () => {
         request: [snakeCase],
         response: [camelCase],
       },
+      version: '2018-09-20',
+    };
+
+    expect(configuration).toEqual(expectedConfiguration);
+  });
+
+  it(`should use the correct defaults when optionals are not provided`, async () => {
+    const configuration = mergeConfigurations({
+      globalConfiguration: { ...globalConfiguration, version: undefined, baseUrl: undefined },
+      localConfiguration,
+    });
+
+    const expectedConfiguration = {
+      baseUrl: 'https://api.teamleader.eu',
+      getAccessToken,
+      plugins: {
+        request: [snakeCase],
+        response: [camelCase],
+      },
+    };
+
+    expect(configuration).toEqual(expectedConfiguration);
+  });
+
+  it(`should prefer the local version over the global version `, async () => {
+    const configuration = mergeConfigurations({
+      globalConfiguration,
+      localConfiguration: { ...localConfiguration, version: '2018-11-20' },
+    });
+
+    const expectedConfiguration = {
+      baseUrl: 'https://test.teamleader.eu',
+      getAccessToken,
+      plugins: {
+        request: [snakeCase],
+        response: [camelCase],
+      },
+      version: '2018-11-20',
     };
 
     expect(configuration).toEqual(expectedConfiguration);


### PR DESCRIPTION
This PR adds the functionality to add a `version` option to the global or local configuration (local one has priority)

as in the README now:

* `version`: (string) specific version of the API in YYYY-MM-DD format (see the [Teamleader documentation](https://developer.teamleader.eu/#/introduction/changes-&-upgrades/upgrading-your-api-version))


`version` can also be provided at a call level, in that case it will override the global setting.

```js
import API from '@teamleader/api';

const { users } = API({
  getAccessToken: () => 'thisisatoken',
  version: '2018-10-30',
});

const init = async () => {
  // (options, plugins)
  const me = await users.me(undefined, { version: '2018-09-12' }); // version 2018-09-12 is used
};
```