### PR TITLE
Validate the provided API version

### DIFF
--- a/src/utils/isValidDate.js
+++ b/src/utils/isValidDate.js
@@ -1,4 +1,4 @@
-export const isValidDate = date => {
+export default date => {
   const API_VERSION_FORMAT_REGEX = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/g;
 
   return API_VERSION_FORMAT_REGEX.test(date) && isValid(date);

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -1,5 +1,5 @@
 import mergePlugins from './mergePlugins';
-import { isValidDate } from './validateDate';
+import isValidDate from './isValidDate';
 
 export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   const { getAccessToken, baseUrl = 'https://api.teamleader.eu', version: globalVersion } = globalConfiguration; // only destruct what we might need on request level

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -1,4 +1,5 @@
 import mergePlugins from './mergePlugins';
+import { isValidDate } from './validateDate';
 
 export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   const { getAccessToken, baseUrl = 'https://api.teamleader.eu', version: globalVersion } = globalConfiguration; // only destruct what we might need on request level
@@ -13,6 +14,10 @@ export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   };
 
   if (localVersion !== undefined) {
+    if (!isValidDate(localVersion)) {
+      throw new Error('The provided local API version is not valid.');
+    }
+
     return {
       ...mergedConfiguration,
       version: localVersion,
@@ -20,6 +25,10 @@ export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   }
 
   if (globalVersion !== undefined) {
+    if (!isValidDate(globalVersion)) {
+      throw new Error('The provided global API version is not valid.');
+    }
+
     return {
       ...mergedConfiguration,
       version: globalVersion,

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -15,7 +15,7 @@ export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
 
   if (localVersion !== undefined) {
     if (!isValidDate(localVersion)) {
-      throw new Error('The provided local API version is not valid.');
+      throw new Error(`'${localVersion}' is not a valid API version.`);
     }
 
     return {
@@ -26,7 +26,7 @@ export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
 
   if (globalVersion !== undefined) {
     if (!isValidDate(globalVersion)) {
-      throw new Error('The provided global API version is not valid.');
+      throw new Error(`'${globalVersion}' is not a valid API version.`);
     }
 
     return {

--- a/src/utils/validateDate.js
+++ b/src/utils/validateDate.js
@@ -1,0 +1,9 @@
+export const isValidDate = date => {
+  const API_VERSION_FORMAT_REGEX = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/g;
+
+  if (!API_VERSION_FORMAT_REGEX.test(date)) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/utils/validateDate.js
+++ b/src/utils/validateDate.js
@@ -1,9 +1,25 @@
 export const isValidDate = date => {
   const API_VERSION_FORMAT_REGEX = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/g;
 
-  if (!API_VERSION_FORMAT_REGEX.test(date)) {
-    return false;
-  }
+  return API_VERSION_FORMAT_REGEX.test(date) && isValid(date);
+};
 
-  return true;
+const daysInMonth = (month, year) => {
+  switch (month) {
+    case 2:
+      return (year % 4 === 0 && year % 100) || year % 400 === 0 ? 29 : 28;
+    case 4:
+    case 6:
+    case 9:
+    case 11:
+      return 30;
+    default:
+      return 31;
+  }
+};
+
+const isValid = date => {
+  const [year, month, day] = date.split('-').map(value => parseInt(value, 10));
+
+  return month >= 1 && month <= 12 && day > 0 && day <= daysInMonth(month, year);
 };

--- a/test/utils/mergeConfigurations.test.js
+++ b/test/utils/mergeConfigurations.test.js
@@ -85,9 +85,10 @@ describe(`merge configurations`, () => {
   it('should throw an error because an invalid global API version was provided', () => {
     expect(() => {
       mergeConfigurations({
+        localConfiguration,
         globalConfiguration: { ...globalConfiguration, version: '2018-12-35' },
       });
-    }).toThrowError('The provided global API version is not valid.');
+    }).toThrowError(`'2018-12-35' is not a valid API version.`);
   });
 
   it('should throw an error because an invalid local API version was provided', () => {
@@ -96,6 +97,6 @@ describe(`merge configurations`, () => {
         localConfiguration: { ...localConfiguration, version: '2018-12-35' },
         globalConfiguration,
       });
-    }).toThrowError('The provided local API version is not valid.');
+    }).toThrowError(`'2018-12-35' is not a valid API version.`);
   });
 });

--- a/test/utils/mergeConfigurations.test.js
+++ b/test/utils/mergeConfigurations.test.js
@@ -81,4 +81,21 @@ describe(`merge configurations`, () => {
 
     expect(configuration.baseUrl).toEqual('https://api.teamleader.eu');
   });
+
+  it('should throw an error because an invalid global API version was provided', () => {
+    expect(() => {
+      mergeConfigurations({
+        globalConfiguration: { ...globalConfiguration, version: '2018-12-35' },
+      });
+    }).toThrowError('The provided global API version is not valid.');
+  });
+
+  it('should throw an error because an invalid local API version was provided', () => {
+    expect(() => {
+      mergeConfigurations({
+        localConfiguration: { ...localConfiguration, version: '2018-12-35' },
+        globalConfiguration,
+      });
+    }).toThrowError('The provided local API version is not valid.');
+  });
 });

--- a/test/utils/validateDate.test.js
+++ b/test/utils/validateDate.test.js
@@ -1,4 +1,4 @@
-import { isValidDate } from '../../src/utils/validateDate';
+import isValidDate from '../../src/utils/isValidDate';
 
 describe('Test the date validator', () => {
   it('should validate the format of the provided date as true', () => {

--- a/test/utils/validateDate.test.js
+++ b/test/utils/validateDate.test.js
@@ -1,0 +1,11 @@
+import { isValidDate } from '../../src/utils/validateDate';
+
+describe('Test the date validator', () => {
+  it('should validate the format of the provided date as true', () => {
+    expect(isValidDate('2019-01-01')).toBe(true);
+  });
+
+  it('should validate the format of the provided date as false', () => {
+    expect(isValidDate('01-01-2019')).toBe(false);
+  });
+});

--- a/test/utils/validateDate.test.js
+++ b/test/utils/validateDate.test.js
@@ -8,4 +8,12 @@ describe('Test the date validator', () => {
   it('should validate the format of the provided date as false', () => {
     expect(isValidDate('01-01-2019')).toBe(false);
   });
+
+  it('should validate the provided date as true', () => {
+    expect(isValidDate('2020-02-29')).toBe(true);
+  });
+
+  it('should validate the provided date as false', () => {
+    expect(isValidDate('2019-02-29')).toBe(false);
+  });
 });


### PR DESCRIPTION
As we can now pass in the API version to the SDK, it only makes sense that we validate this, this PR implements the validation for the API version.