### PR TITLE
[Feature] Make accessToken optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add @teamleader/api
 import API from '@teamleader/api';
 
 const { users } = API({
-  getAccessToken: () => 'thisisatoken', // async or sync function
+  getAccessToken: () => 'thisisatoken',
 });
 
 const init = async () => {
@@ -41,17 +41,34 @@ This module is also available as UMD build (in the example below via unpkg).
 
 ## Configuration
 
-You should provide `getAccessToken` **or** `accessToken`.
+All configuration is optional.
 
-- `getAccessToken`: (function) a (a)sync function that returns a valid access token, triggered on each API call
+`getAccessToken` **or** `accessToken` (when both are provided `getAccessToken` has priority)
+
+- `getAccessToken`: (function) an (a)sync function that returns a valid access token, triggered on each API call
+
+```js
+import API from '@teamleader/api';
+
+const { users } = API({
+  getAccessToken: () => 'thisisatoken',
+});
+```
+
 - `accessToken`: (string) an access token
 
-### optional
+```js
+import API from '@teamleader/api';
+
+const { users } = API({
+  accessToken: 'thisisatoken',
+});
+```
 
 - `baseUrl`: (string) url the sdk should use to call the API (default is set to `https://api.teamleader.eu`)
 - `version`: (string) specific version of the API in YYYY-MM-DD format (see the [Teamleader documentation](https://developer.teamleader.eu/#/introduction/changes-&-upgrades/upgrading-your-api-version))
 
-`version` can also be provided at action level, in that case it will override the root setting.
+`version` can also be provided at local level, in that case it will override the global setting.
 
 ```js
 import API from '@teamleader/api';
@@ -97,10 +114,10 @@ A plugin is a function that receives data (request params or response data) & re
 
 You can provide them in 2 ways.
 
-- `root` level: passed as an extra argument when creating the root object, used for `all routes`
-- `action` level: per route, only triggered on the `provided action` (second argument for the api call)
+- `global` level: passed as an extra argument when creating the API object, used for `all domains`
+- `local` level: per action, only triggered on the `provided action` (second argument for the api call)
 
-If you provide plugins at `root level` and at `action level` they are merged into one plugins array in that order
+If you provide plugins at `global level` and at `local level` they are merged into one plugins array in that order
 
 ```js
 import API from '@teamleader/api';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/src/main.js
+++ b/src/main.js
@@ -1,23 +1,14 @@
 import domains from './config/domains';
 import createDomainWithActions from './utils/createDomainWithActions';
 
-const createGetAccessToken = ({ accessToken, getAccessToken }) => {
-  if (accessToken) {
-    return () => accessToken;
-  }
-
-  return getAccessToken;
-};
-
 const API = globalConfiguration => {
-  const getAccessToken = createGetAccessToken(globalConfiguration);
-  const { baseUrl, plugins, customActions = {} } = globalConfiguration;
+  const { baseUrl, plugins, customActions = {}, accessToken, getAccessToken } = globalConfiguration;
 
   return Object.keys(domains).reduce(
     (apiObject, domainName) => ({
       ...apiObject,
       [domainName]: createDomainWithActions({
-        configuration: { getAccessToken, baseUrl, plugins },
+        configuration: { getAccessToken, baseUrl, plugins, accessToken },
         domainName,
         actions: [...domains[domainName], ...(customActions[domainName] || [])],
       }),

--- a/src/utils/createRequestHeaders.js
+++ b/src/utils/createRequestHeaders.js
@@ -1,17 +1,5 @@
-export default async ({ getAccessToken, version = undefined } = {}) => {
-  const accessToken = await getAccessToken();
-
-  const headers = {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${accessToken}`,
-  };
-
-  if (version !== undefined) {
-    return {
-      ...headers,
-      'X-Api-Version': version,
-    };
-  }
-
-  return headers;
-};
+export default async ({ getAccessToken, version } = {}) => ({
+  'Content-Type': 'application/json',
+  ...(getAccessToken ? { Authorization: `Bearer ${await getAccessToken()}` } : undefined),
+  ...(version ? { 'X-Api-Version': version } : undefined),
+});

--- a/src/utils/createRequestHeaders.js
+++ b/src/utils/createRequestHeaders.js
@@ -1,5 +1,5 @@
 export default async ({ getAccessToken, version } = {}) => ({
   'Content-Type': 'application/json',
-  ...(getAccessToken ? { Authorization: `Bearer ${await getAccessToken()}` } : undefined),
-  ...(version ? { 'X-Api-Version': version } : undefined),
+  ...(getAccessToken && { Authorization: `Bearer ${await getAccessToken()}` }),
+  ...(version && { 'X-Api-Version': version }),
 });

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -1,30 +1,35 @@
 import mergePlugins from './mergePlugins';
 
+const createGetAccessToken = ({ accessToken, getAccessToken }) => {
+  if (getAccessToken) {
+    return getAccessToken;
+  }
+
+  if (accessToken) {
+    return () => accessToken;
+  }
+
+  return undefined;
+};
+
 export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
-  const { getAccessToken, baseUrl = 'https://api.teamleader.eu', version: globalVersion } = globalConfiguration; // only destruct what we might need on request level
+  const {
+    baseUrl = 'https://api.teamleader.eu',
+    version: globalVersion,
+    accessToken,
+    getAccessToken,
+  } = globalConfiguration; // only destruct what we might need on request level
+
   const { version: localVersion } = localConfiguration;
 
   const plugins = mergePlugins(globalConfiguration.plugins, localConfiguration.plugins);
 
-  const mergedConfiguration = {
-    getAccessToken,
+  return {
     baseUrl,
     plugins,
+    ...(accessToken || getAccessToken
+      ? { getAccessToken: createGetAccessToken({ getAccessToken, accessToken }) }
+      : undefined),
+    ...(localVersion || globalVersion ? { version: localVersion || globalVersion } : undefined),
   };
-
-  if (localVersion !== undefined) {
-    return {
-      ...mergedConfiguration,
-      version: localVersion,
-    };
-  }
-
-  if (globalVersion !== undefined) {
-    return {
-      ...mergedConfiguration,
-      version: globalVersion,
-    };
-  }
-
-  return mergedConfiguration;
 };

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -1,17 +1,5 @@
 import mergePlugins from './mergePlugins';
 
-const createGetAccessToken = ({ accessToken, getAccessToken }) => {
-  if (getAccessToken) {
-    return getAccessToken;
-  }
-
-  if (accessToken) {
-    return () => accessToken;
-  }
-
-  return undefined;
-};
-
 export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   const {
     baseUrl = 'https://api.teamleader.eu',
@@ -27,9 +15,7 @@ export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   return {
     baseUrl,
     plugins,
-    ...(accessToken || getAccessToken
-      ? { getAccessToken: createGetAccessToken({ getAccessToken, accessToken }) }
-      : undefined),
+    ...(accessToken || getAccessToken ? { getAccessToken: getAccessToken || (() => accessToken) } : undefined),
     ...(localVersion || globalVersion ? { version: localVersion || globalVersion } : undefined),
   };
 };

--- a/src/utils/mergeConfigurations.js
+++ b/src/utils/mergeConfigurations.js
@@ -15,7 +15,7 @@ export default ({ globalConfiguration = {}, localConfiguration = {} }) => {
   return {
     baseUrl,
     plugins,
-    ...(accessToken || getAccessToken ? { getAccessToken: getAccessToken || (() => accessToken) } : undefined),
-    ...(localVersion || globalVersion ? { version: localVersion || globalVersion } : undefined),
+    ...((accessToken || getAccessToken) && { getAccessToken: getAccessToken || (() => accessToken) }),
+    ...((localVersion || globalVersion) && { version: localVersion || globalVersion }),
   };
 };

--- a/test/utils/createRequestHeaders.test.js
+++ b/test/utils/createRequestHeaders.test.js
@@ -39,4 +39,12 @@ describe(`create header object`, () => {
 
     await expect(createRequestHeaders({ getAccessToken })).resolves.toEqual(headers);
   });
+
+  it(`should only keep content type when no options are provided`, async () => {
+    const headers = {
+      'Content-Type': 'application/json',
+    };
+
+    await expect(createRequestHeaders()).resolves.toEqual(headers);
+  });
 });

--- a/test/utils/mergeConfigurations.test.js
+++ b/test/utils/mergeConfigurations.test.js
@@ -8,6 +8,7 @@ describe(`merge configurations`, () => {
   const globalConfiguration = {
     baseUrl: 'https://test.teamleader.eu',
     getAccessToken,
+    accessToken: 'test',
     wrong_property: 'okokokoko',
     plugins: {
       response: [camelCase],
@@ -32,6 +33,27 @@ describe(`merge configurations`, () => {
         response: [camelCase],
       },
       version: '2018-09-20',
+    };
+
+    expect(configuration).toEqual(expectedConfiguration);
+  });
+
+  it(`should ignore properties when they are not there`, async () => {
+    const customGlobalConfiguration = {
+      baseUrl: 'https://test.teamleader.eu',
+      plugins: {
+        response: [camelCase],
+      },
+    };
+
+    const configuration = mergeConfigurations({ globalConfiguration: customGlobalConfiguration, localConfiguration });
+
+    const expectedConfiguration = {
+      baseUrl: 'https://test.teamleader.eu',
+      plugins: {
+        request: [snakeCase],
+        response: [camelCase],
+      },
     };
 
     expect(configuration).toEqual(expectedConfiguration);

--- a/test/utils/mergeConfigurations.test.js
+++ b/test/utils/mergeConfigurations.test.js
@@ -59,6 +59,19 @@ describe(`merge configurations`, () => {
     expect(configuration).toEqual(expectedConfiguration);
   });
 
+  it(`should create function out of provided accessToken`, async () => {
+    const customGlobalConfiguration = {
+      baseUrl: 'https://test.teamleader.eu',
+      accessToken: 'accessToken',
+      plugins: {
+        response: [camelCase],
+      },
+    };
+
+    const configuration = mergeConfigurations({ globalConfiguration: customGlobalConfiguration, localConfiguration });
+    expect(configuration.getAccessToken()).toEqual(customGlobalConfiguration.accessToken);
+  });
+
   it(`should use the correct defaults when optionals are not provided`, async () => {
     const configuration = mergeConfigurations({
       globalConfiguration: { ...globalConfiguration, version: undefined, baseUrl: undefined },


### PR DESCRIPTION
For the new auth service we want to pass no access token but still use the sdk-js wrapper (through createDomainWithActions)

### Changed

- handle accessToken/getAccessToken inside of mergeConfiguration
- make accessToken/getAccessToken optional