### PR TITLE
Fix/normalize plugin default byId

### DIFF
--- a/src/plugins/normalize.js
+++ b/src/plugins/normalize.js
@@ -1,4 +1,4 @@
 export default ({ data }) => {
   const dataArray = Array.isArray(data) ? data : [data];
-  return dataArray.reduce((o, d) => ({ ...o, byId: { ...o.byId, [d.id]: d } }), {});
+  return dataArray.reduce((o, d) => ({ ...o, byId: { ...o.byId, [d.id]: d } }), { byId: {} });
 };

--- a/src/plugins/normalize.js
+++ b/src/plugins/normalize.js
@@ -1,4 +1,11 @@
 export default ({ data }) => {
-  const dataArray = Array.isArray(data) ? data : [data];
+  let dataArray;
+  if (Array.isArray(data)) {
+    dataArray = data;
+  } else if (Object.keys(data).length === 0) {
+    dataArray = [];
+  } else {
+    dataArray = [data];
+  }
   return dataArray.reduce((o, d) => ({ ...o, byId: { ...o.byId, [d.id]: d } }), { byId: {} });
 };

--- a/test/plugins/normalize.test.js
+++ b/test/plugins/normalize.test.js
@@ -59,4 +59,11 @@ describe(`normalize data`, () => {
       },
     });
   });
+  it(`should empty byId when data is empty`, () => {
+    const data = {};
+
+    expect(normalize({ data })).toEqual({
+      byId: {},
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes an issue in the normalize plugin where `byId` key isn't returned when the data is empty.

#### Before:
```javascript
data: {};
response: {};
```

#### After:
```javascript
data: {};
response: {
  byId: {},
};
```