### PR TITLE
[FEATURE] Add additionalActions configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 
 ### Fixed
 
+## [3.3.0] - 2019-02-26
+
+### Added
+
+- Added `additionalActions` option when configuring the API object ([@duivvv](https://github.com/duivvv) in [#47](https://github.com/teamleadercrm/sdk-js/pull/47))
+
+### Deprecated
+
+- Deprecated `customActions` & `createDomainWithActions` in favour of `additionalActions` ([@duivvv](https://github.com/duivvv) in [#47](https://github.com/teamleadercrm/sdk-js/pull/47))
+
 ## [3.2.2] - 2019-02-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -84,22 +84,22 @@ const init = async () => {
 };
 ```
 
-## Custom actions
+## Additional actions
 
-You can also add extra custom actions to the domains (which will be handled the same way as the available actions).
+You can also add additional actions (the domain will also be created if needed), which will be handled the same way as the available actions.
 
-- `customActions`: (Object) domain as property -> array of actions as value
+- `additionalActions`: (Object) domain as property -> array of actions as value
 
-In the example below we are extending `api.contacts` with `deleted` and `api.tags` with `deleted` and `linkToInvoice`
+In the example below we are extending `api.contacts` with `deleted` and we're adding a `products` domain with a `list` action.
 
 ```js
 import API from '@teamleader/api';
 
 const api = API({
   getAccessToken: () => 'thisisatoken', // async or sync function
-  customActions: {
+  additionalActions: {
     contacts: ['deleted'],
-    tags: ['deleted', 'linkToInvoice'],
+    products: ['list'],
   },
 });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Teamleader API SDK",
   "main": "dist/api.cjs.js",
   "module": "dist/api.esm.js",

--- a/src/main.js
+++ b/src/main.js
@@ -1,21 +1,29 @@
 import domains from './config/domains';
 import createDomainWithActions from './utils/createDomainWithActions';
 
+const mergeDomains = (originalActions, additionalActions) =>
+  Object.keys(additionalActions).reduce((acc, val) => {
+    const mergedActions = [...(originalActions[val] || []), ...(additionalActions[val] || [])];
+    return { ...acc, [val]: mergedActions };
+  }, originalActions);
+
 const API = globalConfiguration => {
-  const { customActions = {} } = globalConfiguration;
+  const { customActions = {}, additionalActions = {} } = globalConfiguration;
+  const mergedDomains = mergeDomains(domains, additionalActions);
+
   if (Object.keys(customActions).length > 0) {
     console.warn(
       '@teamleader/api: customActions will be deprecated in the next minor version, use additionalActions instead.',
     );
   }
 
-  return Object.keys(domains).reduce(
+  return Object.keys(mergedDomains).reduce(
     (apiObject, domainName) => ({
       ...apiObject,
       [domainName]: createDomainWithActions({
         configuration: globalConfiguration,
         domainName,
-        actions: [...domains[domainName], ...(customActions[domainName] || [])],
+        actions: [...mergedDomains[domainName], ...(customActions[domainName] || [])],
       }),
     }),
     {},

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ const API = globalConfiguration => {
 
   if (Object.keys(customActions).length > 0) {
     console.warn(
-      '@teamleader/api: customActions will be deprecated in the next minor version, use additionalActions instead.',
+      '@teamleader/api: `customActions` will be deprecated in a next version, use `additionalActions` instead.',
     );
   }
 
@@ -32,7 +32,7 @@ const API = globalConfiguration => {
 
 const deprecatedCreateDomainWithActions = configuration => {
   console.warn(
-    '@teamleader/api: createDomainWithActions will be deprecated in the next minor version, use additionalActions instead.',
+    '@teamleader/api: `createDomainWithActions` will be deprecated in a next version, use `additionalActions` instead.',
   );
   return createDomainWithActions(configuration);
 };

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,9 @@ import domains from './config/domains';
 import createDomainWithActions from './utils/createDomainWithActions';
 
 const mergeDomains = (originalActions, additionalActions) =>
-  Object.keys(additionalActions).reduce((acc, val) => {
-    const mergedActions = [...(originalActions[val] || []), ...(additionalActions[val] || [])];
-    return { ...acc, [val]: mergedActions };
+  Object.keys(additionalActions).reduce((mergedDomains, domainKey) => {
+    const mergedActions = [...(originalActions[domainKey] || []), ...(additionalActions[domainKey] || [])];
+    return { ...mergedDomains, [domainKey]: mergedActions };
   }, originalActions);
 
 const API = globalConfiguration => {

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,14 @@ const API = globalConfiguration => {
   );
 };
 
-export { default as createDomainWithActions } from './utils/createDomainWithActions';
+const deprecatedCreateDomainWithActions = configuration => {
+  console.warn(
+    '@teamleader/api: createDomainWithActions will be deprecated in the next minor version, use additionalActions instead.',
+  );
+  return createDomainWithActions(configuration);
+};
+
+export { deprecatedCreateDomainWithActions as createDomainWithActions };
 
 export { default as camelCase } from './plugins/camelCase';
 export { default as normalize } from './plugins/normalize';

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,11 @@ import createDomainWithActions from './utils/createDomainWithActions';
 
 const API = globalConfiguration => {
   const { customActions = {} } = globalConfiguration;
+  if (Object.keys(customActions).length > 0) {
+    console.warn(
+      '@teamleader/api: customActions will be deprecated in the next minor version, use additionalActions instead.',
+    );
+  }
 
   return Object.keys(domains).reduce(
     (apiObject, domainName) => ({

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,4 +1,5 @@
-import API, { camelCase, normalize } from '../src/main';
+import API, { camelCase, normalize, createDomainWithActions } from '../src/main';
+import { create } from 'domain';
 
 describe('fetch response handling', () => {
   const mockFetch = desiredResponse => (window.fetch = () => Promise.resolve(desiredResponse));
@@ -44,6 +45,99 @@ describe('fetch response handling', () => {
 
     const dealPhasesMethods = ['list'];
     expect(Object.keys(api.dealPhases).sort()).toEqual(dealPhasesMethods.sort());
+  });
+
+  it('should trigger a deprecation warning when using customActions', () => {
+    const spy = jest.spyOn(global.console, 'warn');
+    API({
+      getAccessToken: () => 'thisisatoken', // async or sync function
+      customActions: {
+        contacts: ['deleted'],
+        activityTypes: ['deleted'],
+      },
+    });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('shoud add the additional domains to the API objects', () => {
+    const api = API({
+      getAccessToken: () => 'thisisatoken', // async or sync function
+      additionalActions: {
+        products: ['list'],
+        contacts: ['deleted'],
+      },
+    });
+
+    const expectedDomains = [
+      'activityTypes',
+      'businessTypes',
+      'companies',
+      'contacts',
+      'creditNotes',
+      'customFieldDefinitions',
+      'dealPhases',
+      'deals',
+      'dealSources',
+      'departments',
+      'events',
+      'invoices',
+      'lostReasons',
+      'products',
+      'milestones',
+      'paymentTerms',
+      'productCategories',
+      'projects',
+      'quotations',
+      'tags',
+      'taxRates',
+      'timers',
+      'timeTracking',
+      'users',
+      'workTypes',
+      'withholdingTaxRates',
+    ];
+
+    expect(Object.keys(api).sort()).toEqual(expectedDomains.sort());
+  });
+
+  it('shoud add the additional action to existing domain', () => {
+    const api = API({
+      getAccessToken: () => 'thisisatoken', // async or sync function
+      additionalActions: {
+        products: ['list'],
+        contacts: ['deleted'],
+      },
+    });
+
+    const expectedContactsMethods = [
+      'add',
+      'delete',
+      'info',
+      'linkToCompany',
+      'list',
+      'tag',
+      'deleted',
+      'unlinkFromCompany',
+      'untag',
+      'update',
+    ];
+
+    expect(Object.keys(api.contacts).sort()).toEqual(expectedContactsMethods.sort());
+  });
+
+  it('shoud add the additional action to a new domain', () => {
+    const api = API({
+      getAccessToken: () => 'thisisatoken', // async or sync function
+      additionalActions: {
+        products: ['list'],
+        contacts: ['deleted'],
+      },
+    });
+
+    const expectedProductsMethods = ['list'];
+
+    expect(Object.keys(api.products).sort()).toEqual(expectedProductsMethods.sort());
   });
 
   it('should run the correct response plugins', () => {
@@ -105,5 +199,12 @@ describe('fetch response handling', () => {
     ];
 
     expect(Object.keys(api).sort()).toEqual(domains.sort());
+  });
+
+  it('should trigger a deprecation warning when using createDomainWithActions', () => {
+    const spy = jest.spyOn(global.console, 'warn');
+    createDomainWithActions();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
### Added

- deprecation warning for `customActions` and `createDomainWithActions`
- `additionalActions` configuration option in `API()`

By using `additionalActions` you should be able to do everything `customActions` & `createDomainWithActions` could.

I'm removing both in a future update, so update your codebase if needed

instead of doing this

```js

import { getAccessToken } from './util';
import { createDomainWithActions } from '@teamleader/api';
import { baseUrl } from './constants';

const configuration = {
  getAccessToken,
  baseUrl,
};

const createConfiguredDomain = (domainName, actions) =>
  createDomainWithActions({
    configuration,
    domainName,
    actions,
  });

export const account = createConfiguredDomain('account', ['info']);
export const discounts = createConfiguredDomain('discounts', ['validate']);
export const subscription = createConfiguredDomain('subscription', ['cancel', 'start', 'downgrade', 'info', 'estimate']);
export const plans = createConfiguredDomain('plans', ['list']);
export const paymentMethod = createConfiguredDomain('paymentMethod', ['info', 'add']);
export const billingInformation = createConfiguredDomain('billingInformation', ['info', 'update']);

```

you should be able to this now

```js

import { getAccessToken } from './util';
import API from '@teamleader/api';

import { baseUrl } from './constants';

export default API({
  getAccessToken,
  baseUrl,
  additionalActions: {
    account: ['info'],
    discounts: ['validate'],
    subscription: ['cancel', 'start', 'downgrade', 'info', 'estimate'],
    plans: ['list'],
    paymentMethod: ['info', 'add'],
    billingInformation: ['info', 'update'], 
  }
})

```

example stolen from payments-frontend 🙈