### PR TITLE
Fix build step

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,16 +3,26 @@
     [
       "@babel/preset-env",
       {
-        "modules": false,
-        "targets": {
-          "browsers": [">0.25%", "not op_mini all"]
-        }
+        "modules": false
       }
     ]
   ],
   "env": {
     "test": {
-      "presets": [["@babel/preset-env"]]
+      "presets": ["@babel/preset-env"]
+    },
+    "es": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "modules": false
+          }
+        ]
+      ]
+    },
+    "cjs": {
+      "presets": ["@babel/preset-env"]
     }
   }
 }

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,2 @@
+>0.25%
+not op_mini all

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "browser": "dist/api.min.umd.js",
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/cli": "^7.4.4",
     "@babel/preset-env": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "humps": "^2.0.1"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build:es": "NODE_ENV=es babel src --out-dir dist/es",
+    "build:cjs": "NODE_ENV=cjs babel src --out-dir dist/cjs",
+    "build:umd": "rollup -c",
+    "build": "npm run build:umd && npm run build:cjs && npm run build:es",
     "start": "rollup -c -w",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@teamleader/api",
   "version": "3.3.0",
   "description": "Teamleader API SDK",
-  "main": "dist/api.cjs.js",
-  "module": "dist/api.esm.js",
+  "main": "dist/cjs/main.js",
+  "module": "dist/es/main.js",
   "browser": "dist/api.min.umd.js",
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,12 +16,12 @@ export default [
       format: 'umd',
     },
     plugins: [
+      resolve(),
       babel({
         externalHelpers: false,
         runtimeHelpers: true,
         exclude: 'node_modules/**',
       }),
-      resolve(),
       commonjs({
         namedExports: {
           'node_modules/humps/humps.js': ['camelizeKeys', 'decamelizeKeys'],
@@ -30,24 +30,5 @@ export default [
       uglify(),
       bundleSize(),
     ],
-  },
-
-  // CommonJS (for Node) and ES module (for bundlers) build.
-  // (We could have three entries in the configuration array
-  // instead of two, but it's quicker to generate multiple
-  // builds from a single configuration where possible, using
-  // an array for the `output` option, where we can specify
-  // `file` and `format` for each target)
-  {
-    input: 'src/main.js',
-    plugins: [
-      babel({
-        externalHelpers: false,
-        runtimeHelpers: true,
-        exclude: 'node_modules/**',
-      }),
-      bundleSize(),
-    ],
-    output: [{ file: pkg.main, format: 'cjs' }, { file: pkg.module, format: 'es' }],
   },
 ];


### PR DESCRIPTION
Before: 

- es / commonjs builds were bundled via Rollup with the dependencies included

After:

- `es` (for tree shaking) and `cjs` folder in `dist` that include the transpiled files 
- change entry points in package.json


Could we have a decent check here, cause this could potentially break stuff if I made a mistake.