### PR TITLE
Undefined access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- If `getAccessToken()` returns `undefined` the authorization header will be omitted ([@ratheDot](https://github.com/rathesDot) in [#55](https://github.com/teamleadercrm/sdk-js/pull/55))
+
 ### Deprecated
 
 ### Removed

--- a/src/utils/createRequestHeaders.js
+++ b/src/utils/createRequestHeaders.js
@@ -1,5 +1,9 @@
-export default async ({ getAccessToken, version } = {}) => ({
-  'Content-Type': 'application/json',
-  ...(getAccessToken && { Authorization: `Bearer ${await getAccessToken()}` }),
-  ...(version && { 'X-Api-Version': version }),
-});
+export default async ({ getAccessToken, version } = {}) => {
+  let accessToken = undefined;
+  return {
+    'Content-Type': 'application/json',
+    ...(getAccessToken &&
+      (accessToken = await getAccessToken()) !== undefined && { Authorization: `Bearer ${accessToken}` }),
+    ...(version && { 'X-Api-Version': version }),
+  };
+};

--- a/src/utils/createRequestHeaders.js
+++ b/src/utils/createRequestHeaders.js
@@ -1,9 +1,8 @@
 export default async ({ getAccessToken, version } = {}) => {
-  let accessToken = undefined;
+  let accessToken = getAccessToken && (await getAccessToken());
   return {
     'Content-Type': 'application/json',
-    ...(getAccessToken &&
-      (accessToken = await getAccessToken()) !== undefined && { Authorization: `Bearer ${accessToken}` }),
+    ...(typeof accessToken !== 'undefined' && { Authorization: `Bearer ${accessToken}` }),
     ...(version && { 'X-Api-Version': version }),
   };
 };

--- a/test/utils/createRequestHeaders.test.js
+++ b/test/utils/createRequestHeaders.test.js
@@ -43,6 +43,22 @@ describe(`create header object`, () => {
     expect(headers).toEqual(testHeaders);
   });
 
+  it(`should not set Auth Header if result is undefined`, async () => {
+    const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    const getAccessToken = async () => {
+      await timeout(200);
+      return undefined;
+    };
+
+    const testHeaders = {
+      'Content-Type': 'application/json',
+    };
+
+    const headers = await createRequestHeaders({ getAccessToken });
+    expect(headers).toEqual(testHeaders);
+  });
+
   it(`should only keep content type when no options are provided`, async () => {
     const headers = {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Before this PR, whenever `getAccessToken()` would return `undefined` as a result, we would end up with an `Authorization Bearer undefined` as a request header.

This PR ensures that the `Authorization` header is not added if the result of `getAccessToken` is `undefined`.

The problem that I'm trying to solve here is a situation that I provide a `getAccessToken()` but it does not always have to have a result. And in that case, I want to send out that request without any `Authorization` header.