### PR TITLE
♻️ Include needs to be passed to create a merge plugin

### DIFF
--- a/src/plugins/merge/merge.js
+++ b/src/plugins/merge/merge.js
@@ -23,7 +23,7 @@ const composeEntity = (entity, path, included) => {
   return mergeIncludedReferenceIntoEntity(entity, included, resolvedReferences, path);
 };
 
-const merge = (response, include) => {
+const merge = include => response => {
   const includePaths = include.split(',');
 
   return {

--- a/test/plugins/merge.test.js
+++ b/test/plugins/merge.test.js
@@ -31,7 +31,7 @@ describe(`merge data`, () => {
       },
     };
 
-    expect(merge(data, 'participant')).toEqual(result);
+    expect(merge('participant')(data)).toEqual(result);
   });
 
   it(`should merge the included data if the main data is an array`, () => {
@@ -87,7 +87,7 @@ describe(`merge data`, () => {
       ],
     };
 
-    expect(merge(data, 'participant')).toEqual(result);
+    expect(merge('participant')(data)).toEqual(result);
   });
 
   it('should merge the data when the parent path is an array', () => {
@@ -184,6 +184,6 @@ describe(`merge data`, () => {
       ],
     };
 
-    expect(merge(data, 'participants')).toEqual(result);
+    expect(merge('participants')(data)).toEqual(result);
   });
 });


### PR DESCRIPTION
Related issue: #31 

### Changed

I've looked into this merge-plugin problem a lot and came to the conclusion that if we want to keep our current implementation of "plugins", this is one of the only solutions to it. So to actually use the `merge` plugin, you need to pass the `include` param to it.

f.e.
```js
API.projects.list({ include: 'participant' }, { plugins: { response: [ merge('participant') ] } })
```

It's not the worst, but also not an ideal solution. I think we should rethink the entire `plugins` implementation in the future. Right now this merge function needs to be called before any other plugin, or it will break the path resolving and it won't be able to merge. And as we add more plugins, every plugin becomes more and more complex.

The reason we have to pass the includes twice (once in the body and once in the plugin) is because the scope of the plugin is limited to the response (it's literally passed under response), but we need the `include` param from the request to know where to merge the entities.

### Next up

Document the merge plugin, adjust the normalize plugin to handle included data.