### PR TITLE
🐛Fix fetchAll option doing wrong requests due to mutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- A bug with the fetchAll option doing the wrong requests ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#196](https://github.com/teamleadercrm/sdk-js/pull/196))
+
 ## [4.0.0] - 2019-08-06
 
 ### Changed

--- a/src/utils/fetchAllRequest.js
+++ b/src/utils/fetchAllRequest.js
@@ -4,7 +4,7 @@ import merge from 'lodash.merge';
 const fetchAllRequest = async (config, amountOfRequests) => {
   const data = await Promise.all(
     [...new Array(amountOfRequests - 1)] // -1 because we already did a firstRequest
-      .map((_, i) => singleRequest(merge(config, { parameters: { page: { number: i + 2 } } }))),
+      .map((_, i) => singleRequest(merge({}, config, { parameters: { page: { number: i + 2 } } }))),
   );
   return data;
 };


### PR DESCRIPTION
### Fixed

- A bug with the fetchAll option doing the wrong requests.

`lodash.merge` mutates, to avoid this, we merge 2 sources into a new object.
