### PR TITLE
🐛make sure amountOfRequests is never 0, fall back to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- A bug with the fetchAll option for empty responses ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#196](https://github.com/teamleadercrm/sdk-js/pull/200))
+
 ## [4.0.1] - 2020-01-13
 
 ### Fixed

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -30,7 +30,8 @@ const request = async ({ domainName, actionName, parameters = {}, configuration 
       },
     } = firstRequestData;
 
-    const amountOfRequests = Math.ceil(matches / size);
+    // Fall back to 1 in case the amount of requests is 0
+    const amountOfRequests = Math.ceil(matches / size) || 1;
 
     // do the 2nd batch in parallel
     const parallelRequestData = await fetchAllRequest({ url, parameters, configuration }, amountOfRequests);


### PR DESCRIPTION
### Fixed

* The package was trying to create an array of length `-1` when the amount of requests is 0 (for empty responses) and thus erroring out.

See:

_fetchAllRequest.js_
```js
 6 [...new Array(amountOfRequests - 1)]
```