### PR TITLE
Remove deprecated `customActions` configuration and `createDomainWithActions` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Removed
 
 - [BREAKING] `additionalHeaders` configuration object, use the new `fetchOptions` configuration with a `headers` property instead ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#322](https://github.com/teamleadercrm/sdk-js/pull/322))
+- [BREAKING] The `customActions` configuration object, use `additionalActions` instead ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#323](https://github.com/teamleadercrm/sdk-js/pull/323))
+- [BREAKING] The `createDomainWithActions` function, use `additionalActions` instead ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#323](https://github.com/teamleadercrm/sdk-js/pull/323))
 
 ### Fixed
 

--- a/src/main.js
+++ b/src/main.js
@@ -7,15 +7,9 @@ const mergeDomains = (originalActions, additionalActions) =>
     return { ...mergedDomains, [domainKey]: mergedActions };
   }, originalActions);
 
-const API = globalConfiguration => {
-  const { customActions = {}, additionalActions = {} } = globalConfiguration;
+const API = (globalConfiguration) => {
+  const { additionalActions = {} } = globalConfiguration;
   const mergedDomains = mergeDomains(domains, additionalActions);
-
-  if (Object.keys(customActions).length > 0) {
-    console.warn(
-      '@teamleader/api: `customActions` will be deprecated in a next version, use `additionalActions` instead.',
-    );
-  }
 
   return Object.keys(mergedDomains).reduce(
     (apiObject, domainName) => ({
@@ -23,14 +17,14 @@ const API = globalConfiguration => {
       [domainName]: createDomainWithActions({
         configuration: globalConfiguration,
         domainName,
-        actions: [...mergedDomains[domainName], ...(customActions[domainName] || [])],
+        actions: mergedDomains[domainName],
       }),
     }),
     {},
   );
 };
 
-const deprecatedCreateDomainWithActions = configuration => {
+const deprecatedCreateDomainWithActions = (configuration) => {
   console.warn(
     '@teamleader/api: `createDomainWithActions` will be deprecated in a next version, use `additionalActions` instead.',
   );

--- a/src/main.js
+++ b/src/main.js
@@ -24,15 +24,6 @@ const API = (globalConfiguration) => {
   );
 };
 
-const deprecatedCreateDomainWithActions = (configuration) => {
-  console.warn(
-    '@teamleader/api: `createDomainWithActions` will be deprecated in a next version, use `additionalActions` instead.',
-  );
-  return createDomainWithActions(configuration);
-};
-
-export { deprecatedCreateDomainWithActions as createDomainWithActions };
-
 export { default as camelCase } from './plugins/camelCase';
 export { default as normalize } from './plugins/normalize';
 export { default as snakeCase } from './plugins/snakeCase';

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -5,49 +5,6 @@ describe('fetch response handling', () => {
     fetch.resetMocks();
   });
 
-  it('should add the customActions to the correct domains', () => {
-    const api = API({
-      getAccessToken: () => 'thisisatoken', // async or sync function
-      customActions: {
-        contacts: ['deleted'],
-        activityTypes: ['deleted'],
-      },
-    });
-
-    const activityTypesMethods = ['list', 'deleted'];
-    expect(Object.keys(api.activityTypes).sort()).toEqual(activityTypesMethods.sort());
-
-    const contactsMethods = [
-      'list',
-      'info',
-      'add',
-      'update',
-      'delete',
-      'tag',
-      'untag',
-      'linkToCompany',
-      'unlinkFromCompany',
-      'deleted',
-    ];
-    expect(Object.keys(api.contacts).sort()).toEqual(contactsMethods.sort());
-
-    const dealPhasesMethods = ['list'];
-    expect(Object.keys(api.dealPhases).sort()).toEqual(dealPhasesMethods.sort());
-  });
-
-  it('should trigger a deprecation warning when using customActions', () => {
-    const spy = jest.spyOn(global.console, 'warn');
-    API({
-      getAccessToken: () => 'thisisatoken', // async or sync function
-      customActions: {
-        contacts: ['deleted'],
-        activityTypes: ['deleted'],
-      },
-    });
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
-  });
-
   it('should add the additional domains to the API objects', () => {
     const api = API({
       getAccessToken: () => 'thisisatoken', // async or sync function
@@ -143,16 +100,12 @@ describe('fetch response handling', () => {
     });
 
     const data = await api.contacts.info({ userId: '84989' }, { plugins: { response: [normalize] } });
-    expect(data).toEqual({ contacts: { '84845512': { id: '84845512', lastName: 'doe', name: 'john' } } });
+    expect(data).toEqual({ contacts: { 84845512: { id: '84845512', lastName: 'doe', name: 'john' } } });
   });
 
   it('should include all domains', () => {
     const api = API({
       getAccessToken: () => 'thisisatoken', // async or sync function
-      customActions: {
-        contacts: ['deleted'],
-        activityTypes: ['deleted'],
-      },
     });
 
     const domains = [

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,4 +1,4 @@
-import API, { camelCase, normalize, createDomainWithActions } from '../src/main';
+import API, { camelCase, normalize } from '../src/main';
 
 describe('fetch response handling', () => {
   beforeEach(() => {
@@ -141,12 +141,5 @@ describe('fetch response handling', () => {
     ];
 
     expect(Object.keys(api).sort()).toEqual(domains.sort());
-  });
-
-  it('should trigger a deprecation warning when using createDomainWithActions', () => {
-    const spy = jest.spyOn(global.console, 'warn');
-    createDomainWithActions();
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
   });
 });


### PR DESCRIPTION
### Removed

- [BREAKING] The `customActions` configuration object, use `additionalActions` instead
- [BREAKING] The `createDomainWithActions` function, use `additionalActions` instead