### PR TITLE
Cache the values that are created by the proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Cache the values that are created by the proxy. So if you call an endpoint 2 times, it will call the same function 2 times. This makes testing easier. ([@lowiebenoot](https://github.com/lowiebenoot) in [#332](https://github.com/teamleadercrm/sdk-js/pull/332))
+
 ### Deprecated
 
 ### Removed

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -41,4 +41,16 @@ describe('fetch response handling', () => {
     const data = await api.contacts.info({ userId: '84989' }, { plugins: { response: [normalize] } });
     expect(data).toEqual({ contacts: { 84845512: { id: '84845512', lastName: 'doe', name: 'john' } } });
   });
+
+  it('using the same endpoint twice actually uses the same function', async () => {
+    const getAccessToken = () => 'thisisatoken';
+
+    const api = API({
+      getAccessToken,
+    });
+
+    expect(api.contacts.info).toEqual(api.contacts.info);
+    expect(api.companies.info).toEqual(api.companies.info);
+    expect(api.companies.info).not.toEqual(api.contacts.info);
+  });
 });


### PR DESCRIPTION
Before this change, if you were using and endpoint 2 times, it would call a different function 2 times. This is very annoying if you are writing tests and expecting a certain endpoint to be called.

A lot of our tests were failing because it expected an endpoint to be called, but since it's always a new function, the functions didn't get called.

Solved if by caching the created functions in an object. If the endpoint has already been called, it will return the previously created function.

Should we release this as a patch or as a minor update?

