### PR TITLE
[6.0.1] - 2022-08-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 ### Changed
 
-- Cache the values that are created by the proxy. So if you call an endpoint 2 times, it will call the same function 2 times. This makes testing easier. ([@lowiebenoot](https://github.com/lowiebenoot) in [#332](https://github.com/teamleadercrm/sdk-js/pull/332))
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+## [6.0.1] - 2022-08-30
+
+### Changed
+
+- Cache the values that are created by the proxy. So if you call an endpoint 2 times, it will call the same function 2 times. This makes testing easier. ([@lowiebenoot](https://github.com/lowiebenoot) in [#332](https://github.com/teamleadercrm/sdk-js/pull/332))
 
 ## [6.0.0] - 2022-08-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Teamleader API SDK",
   "main": "dist/cjs/main.js",
   "module": "dist/es/main.js",


### PR DESCRIPTION
### Changed

- Cache the values that are created by the proxy. So if you call an endpoint 2 times, it will call the same function 2 times. This makes testing easier. ([@lowiebenoot](https://github.com/lowiebenoot) in [#332](https://github.com/teamleadercrm/sdk-js/pull/332))
