### PR TITLE
Allow overwriting the action endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Allow overwriting action endpoints. This is useful for mocking the API. ([@lowiebenoot](https://github.com/lowiebenoot) in [#334](https://github.com/teamleadercrm/sdk-js/pull/334))
+
 ### Deprecated
 
 ### Removed

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -53,4 +53,19 @@ describe('fetch response handling', () => {
     expect(api.companies.info).toEqual(api.companies.info);
     expect(api.companies.info).not.toEqual(api.contacts.info);
   });
+
+  it('can overwrite an endpoint', async () => {
+    const getAccessToken = () => 'thisisatoken';
+
+    const api = API({
+      getAccessToken,
+    });
+
+    const mockFunction = () => {};
+
+    // @ts-ignore
+    api.contacts.info = mockFunction;
+
+    expect(api.contacts.info).toEqual(mockFunction);
+  });
 });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -61,9 +61,7 @@ describe('fetch response handling', () => {
       getAccessToken,
     });
 
-    const mockFunction = () => {};
-
-    // @ts-ignore
+    const mockFunction = jest.fn();
     api.contacts.info = mockFunction;
 
     expect(api.contacts.info).toEqual(mockFunction);

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,18 @@ const API = (globalConfiguration: GlobalConfiguration) => {
               cachedActionEndpoints[domainName][actionName] = actionEndpoint;
               return actionEndpoint;
             },
+            set(_target, actionNameKey, value) {
+              const domainName = String(domainNameKey);
+              const actionName = String(actionNameKey);
+
+              if (typeof cachedActionEndpoints[domainName] === 'undefined') {
+                cachedActionEndpoints[domainName] = {};
+              }
+
+              cachedActionEndpoints[domainName][actionName] = value;
+
+              return true;
+            },
           },
         );
       },


### PR DESCRIPTION
It's not very useful, but it's mostly just for testing, so you can mock it. You can now mock it with jest, which actually overwrites the original function.
For example:
```
jest.spyOn(API.companies, 'info').mockReturnValue(new Promise(jest.fn()));
```