### PR TITLE
Merge `included` when using  `fetchAll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [6.1.0] - 2023-05-10
+
+### Added
+
+- Merge `included` when using `fetchAll` so it can be used in combination with sideloading ([@lorgan3](https://github.com/lorgan3) in [#341](https://github.com/teamleadercrm/sdk-js/pull/341))
+
 ## [6.0.2] - 2022-08-31
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "Teamleader API SDK",
   "main": "dist/cjs/main.js",
   "module": "dist/es/main.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/humps": "^2.0.2",
     "@types/jest": "^28.1.7",
     "@types/lodash.merge": "^4.6.7",
+    "@types/lodash.mergewith": "^4.6.7",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
     "babel-jest": "^28.1.3",
@@ -43,7 +44,8 @@
   },
   "dependencies": {
     "humps": "^2.0.1",
-    "lodash.merge": "^4.6.1"
+    "lodash.merge": "^4.6.1",
+    "lodash.mergewith": "^4.6.2"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -45,6 +45,7 @@ describe('fetch response handling', () => {
       .once(
         JSON.stringify({
           data: [{ name: 'John', last_name: 'Doe' }],
+          included: { team: [{ name: 'Awesome' }] },
           meta: {
             page: {
               size: 1,
@@ -58,6 +59,7 @@ describe('fetch response handling', () => {
       .once(
         JSON.stringify({
           data: [{ name: 'Alex', last_name: 'Turner' }],
+          included: { team: [{ name: 'Champagne' }] },
           meta: {
             page: {
               size: 1,
@@ -71,6 +73,7 @@ describe('fetch response handling', () => {
       .once(
         JSON.stringify({
           data: [{ name: 'William', last_name: 'Hurt' }],
+          included: { team: [] },
           meta: {
             page: {
               size: 1,
@@ -94,6 +97,9 @@ describe('fetch response handling', () => {
         { name: 'Alex', lastName: 'Turner' },
         { name: 'William', lastName: 'Hurt' },
       ],
+      included: {
+        team: [{ name: 'Awesome' }, { name: 'Champagne' }],
+      },
     });
   });
 

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -45,6 +45,66 @@ describe('fetch response handling', () => {
       .once(
         JSON.stringify({
           data: [{ name: 'John', last_name: 'Doe' }],
+          meta: {
+            page: {
+              size: 1,
+              number: 1,
+            },
+            matches: 3,
+          },
+        }),
+        { headers },
+      )
+      .once(
+        JSON.stringify({
+          data: [{ name: 'Alex', last_name: 'Turner' }],
+          meta: {
+            page: {
+              size: 1,
+              number: 2,
+            },
+            matches: 3,
+          },
+        }),
+        { headers },
+      )
+      .once(
+        JSON.stringify({
+          data: [{ name: 'William', last_name: 'Hurt' }],
+          meta: {
+            page: {
+              size: 1,
+              number: 3,
+            },
+            matches: 3,
+          },
+        }),
+        { headers },
+      );
+
+    const jsonResponse = await request({
+      domainName: 'users',
+      actionName: 'list',
+      configuration: { plugins: { response: [camelCase] }, fetchAll: true },
+    });
+
+    expect(jsonResponse).toEqual({
+      data: [
+        { name: 'John', lastName: 'Doe' },
+        { name: 'Alex', lastName: 'Turner' },
+        { name: 'William', lastName: 'Hurt' },
+      ],
+      included: {},
+    });
+  });
+
+  it('returns the correct data with fetchAll and sideloading enabled', async () => {
+    const headers = { 'content-type': 'application/json' };
+
+    fetchMock
+      .once(
+        JSON.stringify({
+          data: [{ name: 'John', last_name: 'Doe' }],
           included: { team: [{ name: 'Awesome' }] },
           meta: {
             page: {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -4,6 +4,7 @@ import mergeArraysOnProperty from './mergeArraysOnProperty';
 import fetchAllRequest from './fetchAllRequest';
 import createRequestUrl from './createRequestUrl';
 import merge from 'lodash.merge';
+import mergeWith from 'lodash.mergewith';
 import { Configuration } from '../types';
 
 const request = async ({
@@ -48,7 +49,14 @@ const request = async ({
     const parallelRequestData = await fetchAllRequest({ url, parameters, configuration }, amountOfRequests);
 
     return applyPlugins(
-      { data: mergeArraysOnProperty('data', firstRequestData, ...parallelRequestData) },
+      {
+        data: mergeArraysOnProperty('data', firstRequestData, ...parallelRequestData),
+        included: mergeWith(
+          firstRequestData.included,
+          ...parallelRequestData.map(({ included }) => included),
+          (objValue: unknown[], srcValue: unknown[]) => objValue.concat(srcValue),
+        ),
+      },
       responsePlugins,
       domainName,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,6 +1513,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.mergewith@^4.6.7":
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz#eaa65aa5872abdd282f271eae447b115b2757212"
+  integrity sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.184"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.184.tgz#23f96cd2a21a28e106dc24d825d4aa966de7a9fe"
@@ -4012,6 +4019,11 @@ lodash.merge@^4.6.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash@^4.17.14, lodash@^4.17.19:
   version "4.17.21"


### PR DESCRIPTION
It was not possible to use sideloading when using `fetchAll` because the `included` data was stripped.
Now it merges all `included` arrays and returns them along with the data.