### PR TITLE
Support fetchall where 2nd request contains more sideloaded subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [6.1.1] - 2024-07-12
+
+### Fixed
+
+- Fix crash when using `fetchAll` and first request contains less sideloaded data than subsequent requests ([@lorgan3](https://github.com/lorgan3) in [#350](https://github.com/teamleadercrm/sdk-js/pull/350))
+
 ## [6.1.0] - 2023-05-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Teamleader API SDK",
   "main": "dist/cjs/main.js",
   "module": "dist/es/main.js",

--- a/src/utils/__tests__/request.test.ts
+++ b/src/utils/__tests__/request.test.ts
@@ -104,6 +104,20 @@ describe('fetch response handling', () => {
     fetchMock
       .once(
         JSON.stringify({
+          data: [{ name: 'Jane', last_name: 'Doe' }],
+          included: {},
+          meta: {
+            page: {
+              size: 1,
+              number: 1,
+            },
+            matches: 4,
+          },
+        }),
+        { headers },
+      )
+      .once(
+        JSON.stringify({
           data: [{ name: 'John', last_name: 'Doe' }],
           included: { team: [{ name: 'Awesome' }] },
           meta: {
@@ -111,7 +125,7 @@ describe('fetch response handling', () => {
               size: 1,
               number: 1,
             },
-            matches: 3,
+            matches: 4,
           },
         }),
         { headers },
@@ -125,7 +139,7 @@ describe('fetch response handling', () => {
               size: 1,
               number: 2,
             },
-            matches: 3,
+            matches: 4,
           },
         }),
         { headers },
@@ -139,7 +153,7 @@ describe('fetch response handling', () => {
               size: 1,
               number: 3,
             },
-            matches: 3,
+            matches: 4,
           },
         }),
         { headers },
@@ -153,6 +167,7 @@ describe('fetch response handling', () => {
 
     expect(jsonResponse).toEqual({
       data: [
+        { name: 'Jane', lastName: 'Doe' },
         { name: 'John', lastName: 'Doe' },
         { name: 'Alex', lastName: 'Turner' },
         { name: 'William', lastName: 'Hurt' },

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -54,7 +54,13 @@ const request = async ({
         included: mergeWith(
           firstRequestData.included,
           ...parallelRequestData.map(({ included }) => included),
-          (objValue: unknown[], srcValue: unknown[]) => objValue.concat(srcValue),
+          (objValue: unknown[] | undefined, srcValue: unknown[]) => {
+            if (!objValue) {
+              return srcValue;
+            }
+
+            return objValue.concat(srcValue);
+          },
         ),
       },
       responsePlugins,


### PR DESCRIPTION
## [6.1.1] - 2024-07-12

- Fix crash when using `fetchAll` and first request contains less sideloaded data than subsequent requests ([@lorgan3](https://github.com/lorgan3) in [#350](https://github.com/teamleadercrm/sdk-js/pull/350))