### PR TITLE
[TIDAL] Fix Rollup build by setting explicit TypeScript include globs

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,7 @@ export default [
     plugins: [
       resolve(),
       typescript({
+        include: ['**/*.ts', '**/*.tsx'],
         tsconfigOverride: {
           exclude: ['**/__tests__', '**/*.test.ts'],
         },


### PR DESCRIPTION
### Description

`yarn build` has been failing with `Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)` on every Node version (16/20/24).

Root cause: `rollup-plugin-typescript2@0.32.1` relies on a default `include` extglob (`["*.ts+(|x)", "**/*.ts+(|x)"]`). The recent `picomatch` bump to 2.3.2 (pulled in via #380) no longer matches that empty-alternation extglob, so the plugin's filter skipped **every** `.ts` file, the TypeScript was never compiled, and Rollup tried to parse raw TS.

Fix: set explicit, plain `include: ['**/*.ts', '**/*.tsx']` globs on the plugin, sidestepping the broken default. Verified `yarn build` now produces all three bundles (cjs/es/umd) on Node 24.

### Manual check

- N/a, adding a build step to ci in a follow up

[Checklist for a thorough manual check](https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3332735012/Manual+check+list)