### PR TITLE
[TIDAL] Add build and npm publish workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+---
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_call:
+
+jobs:
+  build:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn run build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,43 @@
+---
+name: Publish to npm
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # caching node_modules
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn run build
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+      - uses: JS-DevTools/npm-publish@v4
+        env:
+          NODE_AUTH_TOKEN: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [6.2.0] - 2026-06-15
+
+### Changed
+
+- Bump all `@babel/*` dependencies to 7.29.7: `@babel/cli`, `@babel/core`, `@babel/preset-env`, `@babel/preset-typescript` and the transitive `@babel/traverse` ([@lorgan3](https://github.com/lorgan3) in [#353](https://github.com/teamleadercrm/sdk-js/pull/353))
+
 ## [6.1.1] - 2024-07-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/api",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "description": "Teamleader API SDK",
   "main": "dist/cjs/main.js",
   "module": "dist/es/main.js",


### PR DESCRIPTION
### Description

Adds the build + deploy half of an Ahoy-style pipeline for `@teamleader/api`. Tag creation already exists (`create-tag.yaml`);

- **`build.yaml`** — runs `yarn build` on every PR (and is reusable via `workflow_call`). This closes the CI gap that let the Rollup build silently break: none of the existing jobs (lint/test/check-types) actually build the package.
- **`publish.yaml`** — on a published GitHub release, builds and publishes to npm via `JS-DevTools/npm-publish@v4` using npm OIDC trusted publishing, exactly like `ahoy-publish.yaml`.

Full flow: bump `version` in `package.json` on `master` → `create-tag.yaml` cuts a GitHub release → `publish.yaml` fires on `release: published` and publishes. (The release is created with a GitHub App token, so it triggers downstream workflow events.)

[Checklist for a thorough manual check](https://teamleader.atlassian.net/wiki/spaces/ENG/pages/3332735012/Manual+check+list)